### PR TITLE
Update src-cli to include fixed status code check

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM golang:1.13.1-alpine3.10 as builder
 
 # The commit at which to build the sourcegraph cli
-ENV CLI_COMMIT=e007e87db9f48e6c75fe5f3856752d0975778604
+ENV CLI_COMMIT=05d8f25c34bd528cfb386f24126b9412141991a1
 ENV CLONE_URL="https://github.com/sourcegraph/src-cli.git"
 
 RUN apk add --no-cache git=2.22.0-r0


### PR DESCRIPTION
This commit includes https://github.com/sourcegraph/src-cli/pull/59 which fixes the non-zero exit code caused by the changed status code here: https://github.com/sourcegraph/sourcegraph/pull/6227