### PR TITLE
Add input "ignoreFailure" to exit 0

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -15,6 +15,9 @@ inputs:
   public_repo_github_token:
     description: The GitHub access token with `public repo` scope (necessary when uploading to Sourcegraph.com, or any Sourcegraph instance with lsifEnforceAuth set to true)
     default: ''
+  ignore_failure:
+    description: Exit with code 0, even when the upload fails (prevents a red X from showing up in GitHub pull request checks)
+    default: 'true'
 
 runs:
   using: docker
@@ -22,5 +25,6 @@ runs:
   env:
     SRC_ENDPOINT: ${{ inputs.endpoint }}
     PUBLIC_REPO_GITHUB_TOKEN: ${{ inputs.public_repo_github_token }}
+    IGNORE_FAILURE: ${{ inputs.ignore_failure }}
   args:
     - ${{ inputs.file }}

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -21,3 +21,10 @@ env sourcegraph-cli lsif upload \
     "-github-token=${PUBLIC_REPO_GITHUB_TOKEN}" \
     "-skip-validation" \
     "-file=$1"
+
+exitCode="$?"
+if [ "$IGNORE_FAILURE" = "true" ]; then
+    exit 0
+else
+    exit "$exitCode"
+fi


### PR DESCRIPTION
The lsif-upload-action sometimes exits 1, which is easily mistaken for a CI failure which blocks the PR https://github.com/sourcegraph/sourcegraph/runs/305004909

After this change, the default is to ignore upload failures.

See https://sourcegraph.slack.com/archives/CHXHX7XAS/p1573841284419300