### PR TITLE
be precise about the scope needed and what it is for

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ The following input scan be set.
 | ------------------------ | ------------------------- | ----------- |
 | file                     | data.lsif                 | The LSIF dump file to upload. |
 | endpoint                 | `https://sourcegraph.com` | The Sourcegraph instance to target. |
-| github_token |                           | The GitHub access token with `repo` or `public_repo` scope (necessary when uploading to Sourcegraph.com, or any Sourcegraph instance with `lsifEnforceAuth` set to true). |
+| github_token |                           | A GitHub access token with `repo` or `public_repo` scope (necessary when uploading to Sourcegraph.com, or any Sourcegraph instance with `lsifEnforceAuth` set to true). The example below uses `secrets.GITHUB_TOKEN`, which is automatically populated by GitHub. To use a different token (such as one with only `public_repo` scope), [create a repository secret](https://help.github.com/en/actions/automating-your-workflow-with-github-actions/creating-and-using-encrypted-secrets) and refer to that. |
 | ignore_failure           | true                      | Exit with code 0, even when the upload fails (prevents a red X from showing up in GitHub pull request checks). |
 
 The following is a complete example that uses the [Go indexer action](https://github.com/sourcegraph/lsif-go-action) to generate data to upload. Put this in `.github/workflows/lsif.yaml`.

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ The following input scan be set.
 | ------------------------ | ------------------------- | ----------- |
 | file                     | data.lsif                 | The LSIF dump file to upload. |
 | endpoint                 | `https://sourcegraph.com` | The Sourcegraph instance to target. |
-| github_token |                           | A GitHub access token with `repo` or `public_repo` scope (necessary when uploading to Sourcegraph.com, or any Sourcegraph instance with `lsifEnforceAuth` set to true). The example below uses `secrets.GITHUB_TOKEN`, which is automatically populated by GitHub. To use a different token (such as one with only `public_repo` scope), [create a repository secret](https://help.github.com/en/actions/automating-your-workflow-with-github-actions/creating-and-using-encrypted-secrets) and refer to that. |
+| github_token             |                           | A GitHub access token with `repo` or `public_repo` scope (necessary when uploading to Sourcegraph.com, or any Sourcegraph instance with `lsifEnforceAuth` set to true). The example below uses `secrets.GITHUB_TOKEN`, which is automatically populated by GitHub. To use a different token (such as one with only `public_repo` scope), [create a repository secret](https://help.github.com/en/actions/automating-your-workflow-with-github-actions/creating-and-using-encrypted-secrets) and refer to that. |
 | ignore_failure           | true                      | Exit with code 0, even when the upload fails (prevents a red X from showing up in GitHub pull request checks). |
 
 The following is a complete example that uses the [Go indexer action](https://github.com/sourcegraph/lsif-go-action) to generate data to upload. Put this in `.github/workflows/lsif.yaml`.

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ The following input scan be set.
 | ------------------------ | ------------------------- | ----------- |
 | file                     | data.lsif                 | The LSIF dump file to upload. |
 | endpoint                 | `https://sourcegraph.com` | The Sourcegraph instance to target. |
-| public_repo_github_token |                           | The GitHub access token with `public repo` scope (necessary when uploading to Sourcegraph.com, or any Sourcegraph instance with lsifEnforceAuth set to true). |
+| github_token |                           | The GitHub access token with `repo` or `public_repo` scope (necessary when uploading to Sourcegraph.com, or any Sourcegraph instance with `lsifEnforceAuth` set to true). |
 | ignore_failure           | true                      | Exit with code 0, even when the upload fails (prevents a red X from showing up in GitHub pull request checks). |
 
 The following is a complete example that uses the [Go indexer action](https://github.com/sourcegraph/lsif-go-action) to generate data to upload. Put this in `.github/workflows/lsif.yaml`.
@@ -31,6 +31,6 @@ jobs:
       - name: Upload LSIF data
         uses: sourcegraph/lsif-upload-action@master
         with:
-          public_repo_github_token: ${{ secrets.PUBLIC_REPO_GITHUB_TOKEN }}
+          github_token: ${{ secrets.GITHUB_TOKEN }}
           endpoint: https://sourcegraph.com
 ```

--- a/action.yml
+++ b/action.yml
@@ -12,8 +12,8 @@ inputs:
   endpoint:
     description: The URL of the Sourcegraph instance
     default: https://sourcegraph.com
-  public_repo_github_token:
-    description: The GitHub access token with `public repo` scope (necessary when uploading to Sourcegraph.com, or any Sourcegraph instance with lsifEnforceAuth set to true)
+  github_token:
+    description: The GitHub access token with `repo` or `public_repo` scope (necessary when uploading to Sourcegraph.com, or any Sourcegraph instance with `lsifEnforceAuth` set to true)
     default: ''
   ignore_failure:
     description: Exit with code 0, even when the upload fails (prevents a red X from showing up in GitHub pull request checks)
@@ -24,7 +24,7 @@ runs:
   image: Dockerfile
   env:
     SRC_ENDPOINT: ${{ inputs.endpoint }}
-    PUBLIC_REPO_GITHUB_TOKEN: ${{ inputs.public_repo_github_token }}
+    GITHUB_TOKEN: ${{ inputs.github_token }}
     IGNORE_FAILURE: ${{ inputs.ignore_failure }}
   args:
     - ${{ inputs.file }}

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -18,7 +18,7 @@ fi
 env sourcegraph-cli lsif upload \
     "-repo=github.com/${GITHUB_REPOSITORY}" \
     "-commit=${GITHUB_SHA}" \
-    "-github-token=${PUBLIC_REPO_GITHUB_TOKEN}" \
+    "-github-token=${GITHUB_TOKEN}" \
     "-skip-validation" \
     "-file=$1"
 


### PR DESCRIPTION
- The token is not necessarily for public repos only. If you have `lsifEnforceAuth` enabled on a self-hosted instance that contains private GitHub repositories, the GitHub token is not only for public repositories.
- And in that case, the token needs `repo` scope, not just `public_repo` scope.
- Just use the provided-automatically `GITHUB_TOKEN` token by default, to simplify.