### PR TITLE
Do not use built-in token

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ The following input scan be set.
 | ------------------------ | ------------------------- | ----------- |
 | file                     | data.lsif                 | The LSIF dump file to upload. |
 | endpoint                 | `https://sourcegraph.com` | The Sourcegraph instance to target. |
-| github_token             |                           | A GitHub access token with `repo` or `public_repo` scope (necessary when uploading to Sourcegraph.com, or any Sourcegraph instance with `lsifEnforceAuth` set to true). The example below uses `secrets.GITHUB_TOKEN`, which is automatically populated by GitHub. To use a different token (such as one with only `public_repo` scope), [create a repository secret](https://help.github.com/en/actions/automating-your-workflow-with-github-actions/creating-and-using-encrypted-secrets) and refer to that. |
+| github_token             |                           | A GitHub access token with `repo` or `public_repo` scope (necessary when uploading to Sourcegraph.com, or any Sourcegraph instance with `lsifEnforceAuth` set to true). You must [create a repository secret](https://help.github.com/en/actions/automating-your-workflow-with-github-actions/creating-and-using-encrypted-secrets) and refer to that. `GITHUB_TOKEN` does not have sufficient permissions. |
 
 The following is a complete example that uses the [Go indexer action](https://github.com/sourcegraph/lsif-go-action) to generate data to upload. Put this in `.github/workflows/lsif.yaml`.
 
@@ -31,6 +31,6 @@ jobs:
         uses: sourcegraph/lsif-upload-action@master
         continue-on-error: true
         with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
+          github_token: ${{ secrets.LSIF_GITHUB_TOKEN }}
           endpoint: https://sourcegraph.com
 ```

--- a/action.yml
+++ b/action.yml
@@ -13,7 +13,7 @@ inputs:
     description: The URL of the Sourcegraph instance
     default: https://sourcegraph.com
   github_token:
-    description: The GitHub access token with `repo` or `public_repo` scope (necessary when uploading to Sourcegraph.com, or any Sourcegraph instance with `lsifEnforceAuth` set to true)
+    description: The GitHub access token with `repo` or `public_repo` scope (necessary when uploading to Sourcegraph.com, or any Sourcegraph instance with lsifEnforceAuth set to true)
     default: ''
   ignore_failure:
     description: Exit with code 0, even when the upload fails (prevents a red X from showing up in GitHub pull request checks)


### PR DESCRIPTION
Reverts part of https://github.com/sourcegraph/lsif-upload-action/pull/6 (see https://github.com/sourcegraph/lsif-upload-action/pull/6#issuecomment-560932425)