### PR TITLE
Use built-in GITHUB_TOKEN

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,6 @@ The following input scan be set.
 | ------------------------ | ------------------------- | ----------- |
 | file                     | data.lsif                 | The LSIF dump file to upload. |
 | endpoint                 | `https://sourcegraph.com` | The Sourcegraph instance to target. |
-| github_token             |                           | A GitHub access token with `repo` or `public_repo` scope (necessary when uploading to Sourcegraph.com, or any Sourcegraph instance with `lsifEnforceAuth` set to true). You must [create a repository secret](https://help.github.com/en/actions/automating-your-workflow-with-github-actions/creating-and-using-encrypted-secrets) and refer to that. `GITHUB_TOKEN` does not have sufficient permissions. |
 
 The following is a complete example that uses the [Go indexer action](https://github.com/sourcegraph/lsif-go-action) to generate data to upload. Put this in `.github/workflows/lsif.yaml`.
 
@@ -31,6 +30,6 @@ jobs:
         uses: sourcegraph/lsif-upload-action@master
         continue-on-error: true
         with:
-          github_token: ${{ secrets.LSIF_GITHUB_TOKEN }}
+          github_token: ${{ secrets.GITHUB_TOKEN }}
           endpoint: https://sourcegraph.com
 ```

--- a/action.yml
+++ b/action.yml
@@ -13,7 +13,7 @@ inputs:
     description: The URL of the Sourcegraph instance
     default: https://sourcegraph.com
   github_token:
-    description: The GitHub access token with `repo` or `public_repo` scope (necessary when uploading to Sourcegraph.com, or any Sourcegraph instance with lsifEnforceAuth set to true)
+    description: Either 1. a GitHub access token with `repo` or `public_repo` scope, or 2. a GitHub installation access token (necessary when uploading to Sourcegraph.com, or any Sourcegraph instance with lsifEnforceAuth set to true)
     default: ''
   ignore_failure:
     description: Exit with code 0, even when the upload fails (prevents a red X from showing up in GitHub pull request checks)


### PR DESCRIPTION
Now that the built-in GITHUB_TOKEN is supported https://github.com/sourcegraph/sourcegraph/pull/7114, workflows don't need to specify the `github_token` anymore.

This breaks workflows that upload to private Sourcegraph instances that don't have that feature ☝️, but I don't think there are any of them at this time.