### PR TITLE
add ignore_upload_failure option

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM alpine:3.10
 
-ENV CLI_VERSION=3.10.9
+ENV CLI_VERSION=3.12.0
 ENV DOWNLOAD_URL="https://github.com/sourcegraph/src-cli/releases/download/${CLI_VERSION}/src_linux_amd64"
 
 RUN apk add --no-cache \

--- a/README.md
+++ b/README.md
@@ -6,11 +6,12 @@ This action uploads generated LSIF data to a Sourcegraph instance.
 
 The following inputs can be set.
 
-| name     | default                 | description |
-| -------- | ----------------------- | ----------- |
-| file     | dump.lsif               | The LSIF dump file to upload. |
-| root     | ''                      | The root of the LSIF dump. |
-| endpoint | https://sourcegraph.com | The Sourcegraph instance to target. |
+| name                    | default                 | description                                                              |
+| --------                | ----------------------- | -----------                                                              |
+| `file`                  | dump.lsif               | The LSIF dump file to upload.                                            |
+| `root`                  | ''                      | The root of the LSIF dump.                                               |
+| `endpoint`              | https://sourcegraph.com | The Sourcegraph instance to target.                                      |
+| `ignore_upload_failure` | false                   | Permit action to succeed if uploading the LSIF dump to `endpoint` fails. |
 
 The following is a complete example that uses the [Go indexer action](https://github.com/sourcegraph/lsif-go-action) to generate data to upload. Put this in `.github/workflows/lsif.yaml`.
 

--- a/action.yml
+++ b/action.yml
@@ -26,4 +26,5 @@ runs:
     IN: ${{ inputs.file }}
     ROOT: ${{ inputs.root }}
     SRC_ENDPOINT: ${{ inputs.endpoint }}
+    IGNORE_UPLOAD_FAILURE: ${{ inputs.ignore_upload_failure }}
     GITHUB_TOKEN: ${{ inputs.github_token }}

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -15,9 +15,14 @@ if [ -z "$GITHUB_SHA" ]; then
     exit 1
 fi
 
+if [ -z "$IGNORE_UPLOAD_FAILURE" ]; then
+    IGNORE_UPLOAD_FAILIRE="false"
+fi
+
 env src lsif upload \
     "-file=${IN}" \
     "-repo=github.com/${GITHUB_REPOSITORY}" \
     "-commit=${GITHUB_SHA}" \
     "-root=${ROOT}" \
+    "-ignore-upload-failure=${IGNORE_UPLOAD_FAILURE}" \
     "-github-token=${GITHUB_TOKEN}"


### PR DESCRIPTION
Didn't test this yet, will a bit later. But concern right now: Last we chatted `src-cli` needs an updated release such that this flag can be used by this action. Did that happen?