### PR TITLE
Fix default value for upload failure option

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -18,6 +18,9 @@ inputs:
   github_token:
     description: Either 1. a GitHub access token with `repo` or `public_repo` scope, or 2. a GitHub installation access token (necessary when uploading to Sourcegraph.com, or any Sourcegraph instance with lsifEnforceAuth set to true).
     default: ''
+  ignore_upload_failure:
+    description: Whether the action should fail if uploading the lsif dump fails.
+    default: ''
 
 runs:
   using: docker


### PR DESCRIPTION
This needed to be set. If it isn't, you get something like:

```
Run sourcegraph/lsif-upload-action@master
/usr/bin/docker run --name d3e4278519048f4bfa939125f95f20b8e8_35cd34 --label 3888d3 --workdir /github/workspace --rm -e INPUT_ENDPOINT -e INPUT_GITHUB_TOKEN -e INPUT_FILE -e INPUT_ROOT -e IN -e ROOT -e SRC_ENDPOINT -e IGNORE_UPLOAD_FAILURE -e GITHUB_TOKEN -e HOME -e GITHUB_JOB -e GITHUB_REF -e GITHUB_SHA -e GITHUB_REPOSITORY -e GITHUB_REPOSITORY_OWNER -e GITHUB_RUN_ID -e GITHUB_RUN_NUMBER -e GITHUB_ACTOR -e GITHUB_WORKFLOW -e GITHUB_HEAD_REF -e GITHUB_BASE_REF -e GITHUB_EVENT_NAME -e GITHUB_SERVER_URL -e GITHUB_API_URL -e GITHUB_GRAPHQL_URL -e GITHUB_WORKSPACE -e GITHUB_ACTION -e GITHUB_EVENT_PATH -e RUNNER_OS -e RUNNER_TOOL_CACHE -e RUNNER_TEMP -e RUNNER_WORKSPACE -e ACTIONS_RUNTIME_URL -e ACTIONS_RUNTIME_TOKEN -e ACTIONS_CACHE_URL -e GITHUB_ACTIONS=true -e CI=true -v "/var/run/docker.sock":"/var/run/docker.sock" -v "/home/runner/work/_temp/_github_home":"/github/home" -v "/home/runner/work/_temp/_github_workflow":"/github/workflow" -v "/home/runner/work/spoon/spoon":"/github/workspace" 3888d3:e4278519048f4bfa939125f95f20b8e8
invalid boolean value "" for -ignore-upload-failure: parse error
```

and the job fails.